### PR TITLE
fix issue #33 NeworkUsage.cs TupleGetDynamicPortRange  Unhandled exception in GetSystemCpuMemoryValuesAsync with 4 digit 'start port'

### DIFF
--- a/FabricObserver/Observers/Utilities/NetworkUsage.cs
+++ b/FabricObserver/Observers/Utilities/NetworkUsage.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Management;
+using System.Text.RegularExpressions;
 using System.Xml;
 
 namespace FabricObserver.Utilities
@@ -225,12 +226,12 @@ namespace FabricObserver.Utilities
 
                     var stdOutput = p.StandardOutput;
                     string output = stdOutput?.ReadToEnd();
-                    string startPort = output?.Substring(
-                        output.Trim().IndexOf(":") + 2,
-                        output.Substring(output.Trim().LastIndexOf(":") + 2).Length)
-                                                         .Trim(' ', '\r', '\n');
+                    Match match = Regex.Match(output,
+                        @"Start Port\s+:\s+(?<startPort>\d+).+?Number of Ports\s+:\s+(?<numberOfPorts>\d+)",
+                        RegexOptions.Singleline | RegexOptions.IgnoreCase);
 
-                    string portCount = output?.Substring(output.Trim().LastIndexOf(":") + 2).Trim(' ', '\r', '\n');
+                    string startPort = match.Groups["startPort"].Value;
+                    string portCount = match.Groups["numberOfPorts"].Value;
                     string exitStatus = p.ExitCode.ToString();
                     stdOutput?.Close();
 


### PR DESCRIPTION
fix issue #33 NeworkUsage.cs TupleGetDynamicPortRange  Unhandled exception in GetSystemCpuMemoryValuesAsync with 4 digit 'start port'

issue:
C:\>netsh int ipv4 show dynamicportrange tcp

Protocol tcp Dynamic Port Range
---------------------------------
Start Port      : 1024
Number of Ports : 64511

2020-01-16 12:16:52.8537--WARN--FabricObserver service health warning: fabric:/FabricObserver/FabricObserver | NodeObserver | Unhandled exception in GetSystemCpuMemoryValuesAsync: Input string was not in a correct format.: 
    at System.Number.StringToNumber(String str, NumberStyles options, NumberBuffer& number, NumberFormatInfo info, Boolean parseDecimal)
   at System.Number.ParseInt32(String s, NumberStyles style, NumberFormatInfo info)
   at FabricObserver.Utilities.NetworkUsage.TupleGetDynamicPortRange(Protocol protocol) in C:\github\Microsoft\service-fabric-observer\FabricObserver\Observers\Utilities\NetworkUsage.cs:line 242
   at FabricObserver.Utilities.NetworkUsage.GetActiveEphemeralPortCount(Int32 procId, Protocol protocol) in C:\github\Microsoft\service-fabric-observer\FabricObserver\Observers\Utilities\NetworkUsage.cs:line 318
   at FabricObserver.NodeObserver.<>c__DisplayClass61_0.<GetSystemCpuMemoryValuesAsync>b__0() in C:\github\Microsoft\service-fabric-observer\FabricObserver\Observers\NodeObserver.cs:line 268

tests:
Group Name: FabricObserverTests
Duration: 0:02:24.88
0 test(s) failed
0 test(s) skipped
33 test(s) passed
