### PR TITLE
Bug Fix: NetworkUsage.TupleGetFabricApplicationPortRangeForNodeType.

### DIFF
--- a/FabricObserver/Observers/Utilities/NetworkUsage.cs
+++ b/FabricObserver/Observers/Utilities/NetworkUsage.cs
@@ -349,28 +349,18 @@ namespace FabricObserver.Observers.Utilities
                 var nsmgr = new XmlNamespaceManager(xdoc.NameTable);
                 nsmgr.AddNamespace("sf", "http://schemas.microsoft.com/2011/01/fabric");
 
-                // Application Port Range.
-                var endpointsNodeList = xdoc.SelectNodes($"//sf:NodeTypes//sf:NodeType[@Name='{nodeType}']//sf:Endpoints", nsmgr);
+                // SF Application Port Range.
+                var applicationEndpointsNode = xdoc.SelectSingleNode($"//sf:NodeTypes//sf:NodeType[@Name='{nodeType}']//sf:ApplicationEndpoints", nsmgr);
 
-                if (endpointsNodeList == null)
+                if (applicationEndpointsNode == null)
                 {
                     return (-1, -1);
                 }
 
-                var ret = (-1, -1);
+                var ret = (int.Parse(applicationEndpointsNode.Attributes?.Item(0)?.Value ?? "-1"),
+                           int.Parse(applicationEndpointsNode.Attributes?.Item(1)?.Value ?? "-1"));
 
-                foreach (XmlNode node in endpointsNodeList)
-                {
-                    if (node == null || node.ChildNodes.Count < 7)
-                    {
-                        continue;
-                    }
-
-                    ret = (int.Parse(node.ChildNodes[6].Attributes?.Item(0).Value ?? "-1"),
-                           int.Parse(node.ChildNodes[6].Attributes?.Item(1).Value ?? "-1"));
-                }
-
-                reader.Dispose();
+                reader?.Dispose();
 
                 return ret;
             }

--- a/FabricObserver/PackageRoot/ServiceManifest.xml
+++ b/FabricObserver/PackageRoot/ServiceManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ServiceManifest Name="FabricObserverPkg"
-                 Version="2.0.3"
+                 Version="2.0.4"
                  xmlns="http://schemas.microsoft.com/2011/01/fabric"
                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -11,7 +11,7 @@
   </ServiceTypes>
 
   <!-- Code package is your service executable. -->
-  <CodePackage Name="Code" Version="2.0.3">
+  <CodePackage Name="Code" Version="2.0.4">
     <EntryPoint>
       <ExeHost>
         <Program>FabricObserver.exe</Program>
@@ -21,7 +21,7 @@
 
   <!-- Config package is the contents of the Config directory under PackageRoot that contains an 
        independently-updateable and versioned set of custom configuration settings for your service. -->
-  <ConfigPackage Name="Config" Version="2.0.3" />
+  <ConfigPackage Name="Config" Version="2.0.4" />
   <Resources>
     <Endpoints>
       <!-- This endpoint is used by the communication listener to obtain the port on which to 

--- a/FabricObserverApp.nuspec
+++ b/FabricObserverApp.nuspec
@@ -7,7 +7,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>FabricObserver</id>
-    <version>2.0.3</version>
+    <version>2.0.4</version>
     <authors>ctorre</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>This package contains the Service Fabric FabricObserver Application (Config files and Microsoft-signed binaries).</description>

--- a/FabricObserverApp/ApplicationPackageRoot/ApplicationManifest.xml
+++ b/FabricObserverApp/ApplicationPackageRoot/ApplicationManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<ApplicationManifest xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ApplicationTypeName="FabricObserverType" ApplicationTypeVersion="2.0.3" xmlns="http://schemas.microsoft.com/2011/01/fabric">
+<ApplicationManifest xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ApplicationTypeName="FabricObserverType" ApplicationTypeVersion="2.0.4" xmlns="http://schemas.microsoft.com/2011/01/fabric">
   <Parameters>
     <Parameter Name="FabricObserver_InstanceCount" DefaultValue="-1" />
   </Parameters>
@@ -7,7 +7,7 @@
        should match the Name and Version attributes of the ServiceManifest element defined in the 
        ServiceManifest.xml file. -->
   <ServiceManifestImport>
-    <ServiceManifestRef ServiceManifestName="FabricObserverPkg" ServiceManifestVersion="2.0.3" />
+    <ServiceManifestRef ServiceManifestName="FabricObserverPkg" ServiceManifestVersion="2.0.4" />
     <ConfigOverrides />
     <Policies>
       <RunAsPolicy CodePackageRef="Code" UserRef="NetworkUser" />


### PR DESCRIPTION
Correct output for Fabric App port range (ApplicationEndpoints).