### PR TITLE
Fix a memory leaks with windows Process handling

### DIFF
--- a/FabricObserver/Observers/AppObserver.cs
+++ b/FabricObserver/Observers/AppObserver.cs
@@ -148,17 +148,17 @@ namespace FabricObserver.Observers
                             continue;
                         }
 
-                        Process p;
-
+                        string processName;
                         try
                         {
-                            p = Process.GetProcessById((int)repOrInst.HostProcessId);
-
+                            using Process p = Process.GetProcessById((int)repOrInst.HostProcessId);
                             // If the process is no longer running, then don't report on it.
                             if (p.HasExited)
                             {
                                 continue;
                             }
+
+                            processName = p.ProcessName;
                         }
                         catch (Exception e) when (e is ArgumentException || e is InvalidOperationException || e is Win32Exception)
                         {
@@ -167,7 +167,7 @@ namespace FabricObserver.Observers
 
                         string appNameOrType = GetAppNameOrType(repOrInst);
 
-                        var id = $"{appNameOrType}:{p.ProcessName}";
+                        var id = $"{appNameOrType}:{processName}";
 
                         // Log (csv) CPU/Mem/DiskIO per app.
                         if (CsvFileLogger != null && CsvFileLogger.EnableCsvLogging)

--- a/FabricObserver/Observers/ObserverBase.cs
+++ b/FabricObserver/Observers/ObserverBase.cs
@@ -71,9 +71,9 @@ namespace FabricObserver.Observers
             get; set;
         }
 
-        public bool IsEnabled 
-        { 
-            get; set; 
+        public bool IsEnabled
+        {
+            get; set;
         } = true;
 
         public bool IsObserverTelemetryEnabled
@@ -86,7 +86,7 @@ namespace FabricObserver.Observers
             get; set;
         } = false;
 
-        // This static property is *only* used - and set to true - for local development unit test runs. 
+        // This static property is *only* used - and set to true - for local development unit test runs.
         // Do not set this to true otherwise.
         public static bool IsTestRun
         {
@@ -410,14 +410,14 @@ namespace FabricObserver.Observers
             try
             {
                 // This is to ensure friendly-name of resulting dmp file.
-                processName = Process.GetProcessById(processId).ProcessName;
-
+                using Process process = Process.GetProcessById(processId);
+                processName = process.ProcessName;
                 if (string.IsNullOrEmpty(processName))
                 {
                     return false;
                 }
 
-                IntPtr processHandle = Process.GetProcessById(processId).Handle;
+                IntPtr processHandle = process.Handle;
 
                 processName += "_" + DateTime.Now.ToString("ddMMyyyyHHmmss") + ".dmp";
 
@@ -462,7 +462,7 @@ namespace FabricObserver.Observers
         }
 
         /// <summary>
-        /// This function processes numeric data held in FRUD instances and generates Application or Node level Health Reports depending on supplied thresholds. 
+        /// This function processes numeric data held in FRUD instances and generates Application or Node level Health Reports depending on supplied thresholds.
         /// </summary>
         /// <typeparam name="T">This represents the numeric type of data this function will operate on.</typeparam>
         /// <param name="data">FabricResourceUsageData instance.</param>
@@ -543,8 +543,9 @@ namespace FabricObserver.Observers
                 try
                 {
                     if (replicaOrInstance != null && replicaOrInstance.HostProcessId > 0)
+                    using (Process process = Process.GetProcessById((int)replicaOrInstance.HostProcessId))
                     {
-                        procName = Process.GetProcessById((int)replicaOrInstance.HostProcessId).ProcessName;
+                        procName = process.ProcessName;
                     }
                     else
                     {

--- a/FabricObserver/Observers/Utilities/ProcessInfo/WindowsProcessInfoProvider.cs
+++ b/FabricObserver/Observers/Utilities/ProcessInfo/WindowsProcessInfoProvider.cs
@@ -21,7 +21,7 @@ namespace FabricObserver.Observers.Utilities
             const string CategoryName = "Process";
             const string CounterName = "Working Set - Private";
 
-            Process process;
+            Process process = null;
             try
             {
                 process = Process.GetProcessById(processId);
@@ -30,6 +30,7 @@ namespace FabricObserver.Observers.Utilities
             {
                 // "Process with an Id of 12314 is not running."
                 Logger.LogError(ex.Message);
+                process?.Dispose();
                 return 0;
             }
 
@@ -57,6 +58,11 @@ namespace FabricObserver.Observers.Utilities
                     Logger.LogError($"{CategoryName} {CounterName} PerfCounter unhandled error: " + e);
 
                     throw;
+                }
+                finally
+                {
+                    process?.Dispose();
+                    process = null;
                 }
             }
         }


### PR DESCRIPTION
Process implements IDisposable. Every object returned by Process.GetProcessById() will keep lingering in heap until a service instance restarts. 