### PR TITLE
adding warning health event for wrong plugin

### DIFF
--- a/Documentation/Plugins.md
+++ b/Documentation/Plugins.md
@@ -52,7 +52,7 @@ You must implement ObserverBase's two abstract functions:
     }
 ```
 
-5. Build your observer project, drop the output dll and *ALL* of its dependencies, both managed and native (this is *very* important), into the Config/Data/Plugins folder in FabricObserver/PackageRoot. 
+5. Build your observer project, drop the output dll and *ALL* of its dependencies, both managed and native (this is *very* important), into the Data/Plugins folder in FabricObserver/PackageRoot. 
    You can place your plugin dll and all of its dependencies in its own (*same*) folder under the Plugins directory (useful if you have multiple plugins). 
    Again, ALL plugin dll dependencies (and their dependencies, if any) need to live in the *same* folder as the plugin dll.
 

--- a/FabricObserver.Extensibility.nuspec.template
+++ b/FabricObserver.Extensibility.nuspec.template
@@ -5,6 +5,8 @@
 		<version>3.2.12</version>
 		<releaseNotes>
 Note: This is library is required for observer plugins that target FabricObserver 3.2.12. 
+- Updated LVID count monitor to support ESE database performance category change in SF 10.x versions.
+- Adding a warning health event to inform customer if there is an issue with loading plugins.
 		</releaseNotes>
 		<authors>Microsoft</authors>
 		<license type="expression">MIT</license>

--- a/FabricObserver.nuspec.template
+++ b/FabricObserver.nuspec.template
@@ -5,6 +5,7 @@
 		<version>3.2.12</version>
 		<releaseNotes>
 - ESE LVID count monitor updated to support ESE database performance category change in SF 10.x versions.
+- Adding a warning health event to inform customer if there is an issue with loading plugins.
 		</releaseNotes>
 		<authors>Microsoft</authors>
 		<license type="expression">MIT</license>

--- a/FabricObserver/FabricObserver.cs
+++ b/FabricObserver/FabricObserver.cs
@@ -25,7 +25,7 @@ namespace FabricObserver
     internal sealed class FabricObserverService : StatelessService
     {
         private ObserverManager observerManager;
-        readonly Logger logger;
+        private readonly Logger logger;
 
         /// <summary>
         /// Initializes a new instance of the type.

--- a/FabricObserver/FabricObserver.cs
+++ b/FabricObserver/FabricObserver.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using FabricObserver.Observers;
+using FabricObserver.Observers.Utilities;
 using FabricObserver.Utilities;
 using McMaster.NETCore.Plugins;
 using Microsoft.Extensions.DependencyInjection;
@@ -24,6 +25,7 @@ namespace FabricObserver
     internal sealed class FabricObserverService : StatelessService
     {
         private ObserverManager observerManager;
+        readonly Logger logger;
 
         /// <summary>
         /// Initializes a new instance of the type.
@@ -31,7 +33,7 @@ namespace FabricObserver
         /// <param name="context">StatelessServiceContext instance.</param>
         public FabricObserverService(StatelessServiceContext context) : base(context)
         {
-
+            logger = new Logger("FabricObserverService");
         }
 
         /// <summary>
@@ -108,10 +110,11 @@ namespace FabricObserver
 
             PluginLoader[] pluginLoaders = new PluginLoader[pluginDlls.Length];
             Type[] sharedTypes = { typeof(FabricObserverStartupAttribute), typeof(IFabricObserverStartup), typeof(IServiceCollection) };
+            string dll = "";
 
             for (int i = 0; i < pluginDlls.Length; ++i)
             {
-                string dll = pluginDlls[i];
+                dll = pluginDlls[i];
                 PluginLoader loader = PluginLoader.CreateFromAssemblyFile(dll, sharedTypes, a => a.IsUnloadable = false);
                 pluginLoaders[i] = loader;
             }
@@ -148,7 +151,32 @@ namespace FabricObserver
                 }
                 catch (Exception e) when (e is ArgumentException or BadImageFormatException or IOException)
                 {
+                    if(e is IOException)
+                    {
+                        string error = $"Plugin dll {dll} could not be loaded. {e.Message}";
+                        HealthReport healthReport = new()
+                        {
+                            AppName = new Uri($"{Context.CodePackageActivationContext.ApplicationName}"),
+                            EmitLogEvent = true,
+                            HealthMessage = error,
+                            EntityType = Observers.Utilities.Telemetry.EntityType.Application,
+                            HealthReportTimeToLive = TimeSpan.FromMinutes(10),
+                            State = System.Fabric.Health.HealthState.Warning,
+                            Property = "FabricObserverPluginLoadError",
+                            SourceId = $"FabricObserverService-{Context.NodeContext.NodeName}",
+                            NodeName = Context.NodeContext.NodeName,
+                        };
+
+                        ObserverHealthReporter observerHealth = new(logger);
+                        observerHealth.ReportHealthToServiceFabric(healthReport);
+                    }
+
                     continue;
+                }
+                catch (Exception e) when (e is not OutOfMemoryException)
+                {
+                    logger.LogError($"Unhandled exception in FabricObserverService Instance: {e.Message}");
+                    throw;
                 }
             }
         }


### PR DESCRIPTION
Warning given to customer on SFX if there is an issue with their plugin. This is a fix for this bug https://github.com/microsoft/service-fabric-observer/issues/285

![image](https://github.com/microsoft/service-fabric-observer/assets/46803723/eed62bc7-7e7e-477b-b30a-d39c0d9f1509)
