### PR TITLE
Octokit check github version config

### DIFF
--- a/FabricObserver.Extensibility/Utilities/ObserverConstants.cs
+++ b/FabricObserver.Extensibility/Utilities/ObserverConstants.cs
@@ -18,6 +18,7 @@ namespace FabricObserver.Observers.Utilities
         public const string EnableFabricObserverOperationalTelemetry = "EnableFabricObserverOperationalTelemetry";
         public const string AsyncClusterOperationTimeoutSeconds = "ClusterOperationTimeoutSeconds";
         public const string ObserverFailureHealthStateLevelParameter = "ObserverFailureHealthStateLevel";
+        public const string CheckGithubVersion = "CheckGithubVersion";
 
         // The name of the package that contains this Observer's configuration
         public const string ObserverConfigurationPackageName = "Config";

--- a/FabricObserver/Observers/ObserverManager.cs
+++ b/FabricObserver/Observers/ObserverManager.cs
@@ -260,11 +260,15 @@ namespace FabricObserver.Observers
                             }
                         }
 
-                        // Check for new version once a day.
-                        if (!(shutdownSignaled || runAsyncToken.IsCancellationRequested) && DateTime.UtcNow.Subtract(LastVersionCheckDateTime) >= NewReleaseCheckInterval)
+                        _ = bool.TryParse(GetConfigSettingValue(ObserverConstants.CheckGithubVersion, null), out bool checkGithubVersion);
+                        if (checkGithubVersion)
                         {
-                            await CheckGithubForNewVersionAsync();
-                            LastVersionCheckDateTime = DateTime.UtcNow;
+                            // Check for new version once a day.
+                            if (!(shutdownSignaled || runAsyncToken.IsCancellationRequested) && DateTime.UtcNow.Subtract(LastVersionCheckDateTime) >= NewReleaseCheckInterval)
+                            {
+                                await CheckGithubForNewVersionAsync();
+                                LastVersionCheckDateTime = DateTime.UtcNow;
+                            }
                         }
 
                         // Time to tale a nap before running observers again. 30 seconds is the minimum sleep time.

--- a/FabricObserver/PackageRoot/Config/Settings.xml
+++ b/FabricObserver/PackageRoot/Config/Settings.xml
@@ -49,6 +49,9 @@
     <!-- Required: Diagnostic Telemetry. Azure ApplicationInsights and Azure LogAnalytics support is already implemented, 
          but you can implement whatever provider you want. See IObserverTelemetry interface. -->
     <Parameter Name="EnableTelemetryProvider" Value="" MustOverride="true" />
+      
+    <!-- Optional: Octokit Github Version check. If set to true FO will emit a health event if there is a new version of FO available -->
+    <Parameter Name="CheckGithubVersion" Value="" MustOverride="true" />
 	  
     <!-- Telemetry - ApplicationInsights/LogAnalytics. NOTE: Values must now be set in ApplicationManifest.xml. This is a *breaking change* in version 3.2.15. -->
 	  

--- a/FabricObserverApp/ApplicationPackageRoot/ApplicationManifest.xml
+++ b/FabricObserverApp/ApplicationPackageRoot/ApplicationManifest.xml
@@ -23,6 +23,8 @@
          This is primarily useful for scenarios where you have multiple instances of FO running on a node and you want to ensure that each instance writes 
          ETW event data to different named sinks. This is more of an advanced scenario. In general, just leave this blank. -->
     <Parameter Name="ObserverManagerETWProviderName" DefaultValue="" />
+    <!-- Set this parameter to true if you want FO to emit a health event letting you know if there is a new version of FO available. Otherwise, set this to false. -->
+    <Parameter Name="ObserverManagerCheckGithubVersion" DefaultValue="true" />
     <!-- If you want FO to transmit telemetry data events to ApplicationInsights or LogAnalytics, for example, then enable this setting. Otherwise, set this to false. -->
     <!-- Observer Telemetry -->
     <Parameter Name="ObserverManagerEnableTelemetryProvider" DefaultValue="true" />
@@ -429,6 +431,7 @@
             <Parameter Name="ObserverFailureHealthStateLevel" Value="[ObserverManagerObserverFailureHealthStateLevel]" />
             <Parameter Name="ObserverLogPath" Value="[ObserverLogPath]" />
             <Parameter Name="TelemetryProvider" Value="[TelemetryProvider]" />
+            <Parameter Name="CheckGithubVersion" Value="[ObserverManagerCheckGithubVersion]" />
             <!-- Application Insights -->
             <Parameter Name="AppInsightsConnectionString" Value="[AppInsightsConnectionString]" />
             <!-- LogAnalytics -->


### PR DESCRIPTION
The purpose of this PR is because Octokit/Github Version Check cannot be used in airgapped clusters. So making the Github Version Check a configurable setting. Tested config change using breakpoints and existing tests pass.